### PR TITLE
chore: update aws/aws-cli 2.7.22 to 2.11.21

### DIFF
--- a/pkgs/aws/aws-cli/pkg.yaml
+++ b/pkgs/aws/aws-cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: aws/aws-cli@2.7.22
+  - name: aws/aws-cli@2.11.21


### PR DESCRIPTION
[2.11.21](https://github.com/aws/aws-cli/releases/tag/2.11.21) [compare](https://github.com/aws/aws-cli/compare/2.7.22...2.11.21)